### PR TITLE
gunicorn and hpa

### DIFF
--- a/.k8s/deployment.yaml
+++ b/.k8s/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: mypizza-deployment
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: mypizza

--- a/.k8s/hpa.yaml
+++ b/.k8s/hpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: mypizza
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mypizza-deployment
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 50

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 8000
 
 
 # Command to run your application
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "mypizza.wsgi:application"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Django>=3.0,<4.0
+psycopg2-binary
+gunicorn>=20.0,<21.0


### PR DESCRIPTION
this PR adds the [gunicorn](https://gunicorn.org/)  Python WSGI  as Interface and [hpa](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for the k8s scalability based on cpu